### PR TITLE
Use triple backticks for code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,10 @@ The usage documentation below is an example of the output.
 
 Generate command documentation for a Readme file.
 
-    generate-readme [-i|--include INCLUDE] [-r|--readme README] [-u|--usage USAGE]
+
+```console
+generate-readme [-i|--include INCLUDE] [-r|--readme README] [-u|--usage USAGE]
+```
 
 * `--include` `-i` — Explicitly include a command (e.g. "app:foo") or namespace (e.g. "app:" with trailing colon).
   This option can be provided multiple times.

--- a/src/Command/ReadmeGenCommand.php
+++ b/src/Command/ReadmeGenCommand.php
@@ -67,7 +67,7 @@ class ReadmeGenCommand extends Command
             $description = $command->getDescription() ? $command->getDescription() . "\n\n" : '';
             $commandInfo .= "\n### " . $command->getName() . "\n\n"
                 . $description
-                . '    ' . $command->getSynopsis() . "\n\n"
+                . "\n```console\n" . $command->getSynopsis() . "\n```\n\n"
                 . $this->formatOptions($command->getDefinition()->getOptions())
                 . $this->formatArguments($command->getDefinition()->getArguments());
         }


### PR DESCRIPTION
This is a common recommendation for markdown, since implicit indentation-based code blocks are easy to miss when editing the file, and can interfere with other sources of indentation (e.g. list items).