### PR TITLE
Remove extraneous newline, and simplify CI config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,18 @@
 name: CI
 
-on: ['push', 'pull_request']
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - '**'
 
 jobs:
   build:
 
     strategy:
       matrix:
-        # All supported PHP versions https://www.php.net/supported-versions.php
         php: [ '7.3', '7.4', '8.0', '8.1', '8.2' ]
 
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ The usage documentation below is an example of the output.
 
 Generate command documentation for a Readme file.
 
-
 ```console
 generate-readme [-i|--include INCLUDE] [-r|--readme README] [-u|--usage USAGE]
 ```

--- a/src/Command/ReadmeGenCommand.php
+++ b/src/Command/ReadmeGenCommand.php
@@ -64,7 +64,7 @@ class ReadmeGenCommand extends Command
         $commandInfo = '';
         foreach ($commands as $command) {
             $io->writeln('Processing command: ' . $command->getName());
-            $description = $command->getDescription() ? $command->getDescription() . "\n\n" : '';
+            $description = $command->getDescription() ? $command->getDescription() . "\n" : '';
             $commandInfo .= "\n### " . $command->getName() . "\n\n"
                 . $description
                 . "\n```console\n" . $command->getSynopsis() . "\n```\n\n"


### PR DESCRIPTION
* Remove the additional newline that was being inserted above the command usage code block.
* Run CI on PRs and pushes to main, and not pushes to PRs.